### PR TITLE
Use namespace URL for RDF tag

### DIFF
--- a/PlantUmlViewer/PlantUmlViewer/Forms/PreviewWindow.cs
+++ b/PlantUmlViewer/PlantUmlViewer/Forms/PreviewWindow.cs
@@ -542,7 +542,6 @@ namespace PlantUmlViewer.Forms
             //Add metadata
             SvgUnknownElement metadata = new SvgUnknownElement("metadata");
             NonSvgElement rdfMetadata = new NonSvgElement("RDF", NAMESPACE_RDF);
-            rdfMetadata.Namespaces["rdf"] = NAMESPACE_RDF;
             rdfMetadata.Namespaces["dc"] = NAMESPACE_DC;
             rdfMetadata.Namespaces["puv"] = NAMESPACE_PUV;
 

--- a/PlantUmlViewer/PlantUmlViewer/Forms/PreviewWindow.cs
+++ b/PlantUmlViewer/PlantUmlViewer/Forms/PreviewWindow.cs
@@ -541,7 +541,7 @@ namespace PlantUmlViewer.Forms
 
             //Add metadata
             SvgUnknownElement metadata = new SvgUnknownElement("metadata");
-            NonSvgElement rdfMetadata = new NonSvgElement("RDF", "rdf");
+            NonSvgElement rdfMetadata = new NonSvgElement("RDF", NAMESPACE_RDF);
             rdfMetadata.Namespaces["rdf"] = NAMESPACE_RDF;
             rdfMetadata.Namespaces["dc"] = NAMESPACE_DC;
             rdfMetadata.Namespaces["puv"] = NAMESPACE_PUV;


### PR DESCRIPTION
XML check of Notepad++complained on the generated SVG file: XMP Parsing error at line xx: xmlns: URI rdf is not absolute. This is caused by the following XML tag:

    <RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:puv="https://github.com/Fruchtzwerg94/PlantUmlViewer" xmlns="rdf">

The value of the xmlns tag should be the name of an XML namespace.

I changed the namespace to "http://www.w3.org/1999/02/22-rdf-syntax-ns#" and Notepad++ does not complain anymore.

